### PR TITLE
Add the option to add custom format tokens

### DIFF
--- a/lib/timeliness/definitions.rb
+++ b/lib/timeliness/definitions.rb
@@ -246,6 +246,25 @@ module Timeliness
         end
       end
 
+      #
+      # Add new tokens for format construction.
+      # It expects a hash where the key is the token string,
+      #   and the value a token array.
+      # The token array is made of regexp and key for format
+      #   component mapping, if any.
+      #
+      # Ex.:
+      #   {
+      #     '%Y' => [ '\d{4}', :year ],
+      #     '%m' => [ '\d{2}', :month ],
+      #     '%d' => [ '\d{2}', :day ]
+      #   }
+      #
+      def add_format_tokens(format_token)
+        @format_tokens.merge!(format_token)
+
+        compile_formats
+      end
     end
   end
 end

--- a/spec/timeliness/definitions_spec.rb
+++ b/spec/timeliness/definitions_spec.rb
@@ -113,4 +113,17 @@ describe Timeliness::Definitions do
       threads.each { |t| expect(t.value).to eql(Time.new(2016,06,30)) }
     end
   end
+
+  context "add_format_tokens" do
+    it "should allow add custom format tokens" do
+      expect(parser._parse('01/02/2000', :date, format: '%d/%m/%Y')).to be_nil
+      definitions.add_format_tokens({
+        '%Y' => [ '\d{4}', :year ],
+        '%m' => [ '\d{2}', :month ],
+        '%d' => [ '\d{2}', :day ]
+      })
+
+      expect(parser._parse('01/02/2000', :date, format: '%d/%m/%Y')).to eq [2000,2,1,nil,nil,nil,nil,nil]
+    end
+  end
 end

--- a/spec/timeliness/definitions_spec.rb
+++ b/spec/timeliness/definitions_spec.rb
@@ -115,14 +115,13 @@ describe Timeliness::Definitions do
   end
 
   context "add_format_tokens" do
-    it "should allow add custom format tokens" do
+    it "should allow adding custom format tokens" do
       expect(parser._parse('01/02/2000', :date, format: '%d/%m/%Y')).to be_nil
       definitions.add_format_tokens({
         '%Y' => [ '\d{4}', :year ],
         '%m' => [ '\d{2}', :month ],
         '%d' => [ '\d{2}', :day ]
       })
-
       expect(parser._parse('01/02/2000', :date, format: '%d/%m/%Y')).to eq [2000,2,1,nil,nil,nil,nil,nil]
     end
   end


### PR DESCRIPTION
The intention is complement the possibility to add new formats that eventually is already in use on projects that integrate Timeliness.
But on top of that, the option to use the tokens broadly used on existing projects in ruby, based on `strptime` tokens, like `%Y-%m-%d`.

The use would be

```
Timeliness.add_format_tokens({
  '%Y' => ['\d{4}', :year],
  '%m' => ['\d{2}', :month],
  '%d' => ['\d{2}', :day]
})
Timeliness.parse('2019-04-25', :date, format: '%Y-%m-%d')
```